### PR TITLE
[ci-cd] fix: docker run fail case

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -41,9 +41,11 @@ jobs:
           script: |
             docker ps
             docker stop frontend
+            docker rm frontend
             docker pull ${{ secrets.DOCKER_USERNAME }}/preznto:${{ github.sha }}
             docker run -d -p 8080:8080 --name frontend ${{ secrets.DOCKER_USERNAME }}/preznto:${{ github.sha }}
             docker image prune -f
+            exit $(docker inspect frontend --format='{{.State.ExitCode}}')
 
       - name: Deploy Discord Notification
         uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
[cd]
- cd pipeline 에서 docker conatiner를 stop만 시키고 삭제하지 않아서 duplicate로 docker가 동일한 컨테이름 이름으로  run 되지 않았음.
- docker run 이 실패하였는데도 success 로직을 타고 있어서 수정함